### PR TITLE
Configure production deployment with HTTPS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./backend:/app
     environment:
       - FLASK_ENV=production
+    restart: unless-stopped
 
   frontend:
     build:
@@ -18,5 +19,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "80:80"
+      - "443:443"
     depends_on:
       - backend
+    restart: unless-stopped
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - /var/lib/letsencrypt:/var/lib/letsencrypt:ro

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>MNIST from Scratch</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -1,5 +1,33 @@
+# HTTP server - redirects to HTTPS
 server {
     listen 80;
+    server_name scratchmnist.org www.scratchmnist.org;
+    
+    # Redirect all HTTP traffic to HTTPS
+    return 301 https://$server_name$request_uri;
+}
+
+# HTTPS server
+server {
+    listen 443 ssl http2;
+    server_name scratchmnist.org www.scratchmnist.org;
+
+    # SSL Configuration
+    ssl_certificate /etc/letsencrypt/live/scratchmnist.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/scratchmnist.org/privkey.pem;
+    
+    # Modern SSL configuration
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    # Security headers
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options DENY always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-XSS-Protection "1; mode=block" always;
 
     # Serve static frontend files
     location / {
@@ -15,5 +43,11 @@ server {
         proxy_set_header Connection keep-alive;
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+        
+        # Additional headers for HTTPS
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
     }
 }


### PR DESCRIPTION
>
> - Updated Flask routes to include /api prefix for nginx proxy
> - Configured nginx with HTTPS support and SSL certificates
> - Updated docker-compose.yml for production with SSL volume mounts
> - Added domain configuration for scratchmnist.org
> - Set Flask environment to production mode